### PR TITLE
Fix for packages trying to use platform.uname() calls

### DIFF
--- a/sauna/reload/__init__.py
+++ b/sauna/reload/__init__.py
@@ -43,3 +43,7 @@ forkloop.startBootTimer()
 # Hook into PEP 302 laoder
 from sauna.reload.monkeypatcher import MonkeyPatchingLoader
 __loader__ = MonkeyPatchingLoader(sys.modules[__name__])
+
+# Prepopulate platform.uname, before it gets lost in the stack
+import platform
+uname = platform.uname()


### PR DESCRIPTION
I ran into an issue with a package (requests) using calls to platform.system() and platform.release() throwing IOErrors. It seems that anything using platform.uname() values fails with an IOError(10). 
