### PR TITLE
In Zope version >= 2.13.19 the storage is explicitly closed on shutdown....

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,15 +4,16 @@ Changelog
 0.5.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Check if the storage connection has already been closed before trying to
+  close it. Zope versions >= 2.13.19 explicitly close the connection on shutdown.
+  [sunew]
 
 0.5.2 (2014-10-18)
 ------------------
 
 - Log 'cannot reload' as warning instead of error to avoid triggering
   postmortem debugging
-  [sune]
+  [sunew]
 
 0.5.1 (2013-02-20)
 ------------------

--- a/sauna/reload/adapters.py
+++ b/sauna/reload/adapters.py
@@ -115,11 +115,13 @@ class ZEOClientStorageDatabaseHooksAdapter(object):
         self.context._cache.close()
 
     def prepareForReload(self):
-        # Close the connection (before the child is killed)
         _rpc_mgr = self.context._rpc_mgr
-        _rpc_mgr.close()
-        # Close the cache (before the child is killed)
-        self.context._cache.close()
+        if self.context.is_connected():
+            # Close the connection (before the child is killed)
+            _rpc_mgr.close()
+
+            # Close the cache (before the child is killed)
+            self.context._cache.close()
 
     def resumeFromReload(self):
         # Open a new cache for the new child


### PR DESCRIPTION
... This caused an attribute error on reload, since the _rpc_mgr was None. Test for is_connected before closing connection and cache.

The error happening on every reload for Zope>= 2.13.19, plone versions 4.2 and above:

```
2014-10-19 12:14:08 INFO Z2 Shutting down
2014-10-19 12:14:08 INFO ZEO.ClientStorage zeostorage Disconnected from storage: "('localhost', 50001)"
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "/usr/lib/python2.7/atexit.py", line 24, in _run_exitfuncs
    func(*targs, **kargs)
  File "/work/tools/plone4/plone4.3-std/mr-developer-src/sauna.reload/sauna/reload/forkloop.py", line 249, in _childExitHandler
    self.database.prepareForReload()
  File "/work/tools/plone4/plone4.3-std/mr-developer-src/sauna.reload/sauna/reload/adapters.py", line 41, in prepareForReload
    return self.context.prepareForReload()
  File "/work/tools/plone4/plone4.3-std/mr-developer-src/sauna.reload/sauna/reload/adapters.py", line 120, in prepareForReload
    _rpc_mgr.close()
AttributeError: 'NoneType' object has no attribute 'close'
```

Reload was still working - this bug just made a lot of noise.

See https://zope.readthedocs.org/en/2.13/CHANGES.html for the changelog on Zope 2.13.19.
